### PR TITLE
Update .stripNewlines() to handle any combination of newlines

### DIFF
--- a/lib/ddata.js
+++ b/lib/ddata.js
@@ -866,7 +866,7 @@ function indent(input){
 @static
 */
 function stripNewlines(input){
-    if (input) return input.replace(/(\n|\r\n)+/g, " ");
+    if (input) return input.replace(/[\r\n]+/g, " ");
 }
 
 /**


### PR DESCRIPTION
I was seeing a weird case on my Windows machine where `.stripNewlines()` was receiving a string with `\r` characters but no `\n` characters.

This patch updates `.stripNewlines()` to handle any combination of newline characters, which includes the case I was seeing and several others.